### PR TITLE
Skip __metal_call if METAL_UNIT_ONLY_ERRORS/WARNINGS set

### DIFF
--- a/include/metal/unit.def
+++ b/include/metal/unit.def
@@ -67,6 +67,12 @@ void __metal_unit_break(__metal_level lvl,
 #define __metal_unit_impl(...) __metal_unit_break(__VA_ARGS__)
 #endif
 
+#if defined(METAL_UNIT_ONLY_ERRORS) || defined(METAL_UNIT_ONLY_WARNINGS)
+#define __metal_unit_call(Function, ...) Function()
+#else
+#define __metal_unit_call(...) __metal_call(__VA_ARGS__)
+#endif
+
 int __metal_report();
 
 #define __METAL_BITWISE_STEP(Lhs, Rhs, Index, Oper) (((Lhs >> Index) & 1) Oper ((Rhs >> Index) & 1))

--- a/include/metal/unit.h
+++ b/include/metal/unit.h
@@ -18,7 +18,7 @@
 #define METAL_ERRORED()     +__metal_errored
 #define METAL_IS_CRITICAL() +__metal_critical
 
-#define METAL_CALL(Function, Message) __metal_call(Function, Message, __FILE__, __LINE__);
+#define METAL_CALL(Function, Message) __metal_unit_call(Function, Message, __FILE__, __LINE__);
 
 #define METAL_REPORT() __metal_report()
 


### PR DESCRIPTION
Will further mess up logging statistics, but succesfully reduces test output to failures/warnings only for me.

Re issue klemens-morgenstern#8